### PR TITLE
Don't depend on `/tmp` existance

### DIFF
--- a/env/sdkmandir_test.go
+++ b/env/sdkmandir_test.go
@@ -1,36 +1,79 @@
 package env
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSdkmanDirNoEnvVar(t *testing.T) {
-	os.Unsetenv(sdkmanDirEnv)
+func TestSdkmanDir(t *testing.T) {
+	// Prepare for environment variable operations.
+	saved, ok := os.LookupEnv(sdkmanDirEnv)
+	if ok {
+		t.Logf("saving %s (= %s)", sdkmanDirEnv, saved)
+	}
+	defer (func() {
+		if ok {
+			_ = os.Setenv(sdkmanDirEnv, saved)
+			t.Logf("restore %s to \"%s\"", sdkmanDirEnv, saved)
+		}
+	})()
 
-	actual := SdkmanDir()
+	t.Run(fmt.Sprintf("Obtain sdkman home dir without %s", sdkmanDirEnv), func(t *testing.T) {
+		os.Unsetenv(sdkmanDirEnv)
 
-	homeDir, err := homedir.Dir()
-	check(err)
-	expected := filepath.Join(homeDir, baseFolder)
+		actual := SdkmanDir()
 
-	assert.Equal(t, expected, actual, "no sdkman dir default value when SDKMAN_DIR env var unset")
+		homeDir, err := homedir.Dir()
+		if err != nil {
+			t.Fatalf("failed to obtain the home directory (%#v)", err)
+		}
+		expected := filepath.Join(homeDir, baseFolder)
+
+		assert.Equal(t, expected, actual, "no sdkman dir default value when SDKMAN_DIR env var unset")
+	})
+	t.Run(fmt.Sprintf("Obtain sdkman home dir under %s existed", sdkmanDirEnv), func(t *testing.T) {
+		sdkmanDir, err := ioutil.TempDir("", "sdkman-")
+		if err != nil {
+			t.Fatalf("failed to create temporary directory (%#v)", err)
+		}
+		t.Logf("sdkmanDir = %s", sdkmanDir)
+		defer (func(keep bool) {
+			if !keep {
+				_ = os.RemoveAll(sdkmanDir)
+				t.Logf("%s deleted", sdkmanDir)
+			}
+		})(doKeepTemp())
+
+		os.Setenv(sdkmanDirEnv, sdkmanDir)
+
+		actual := SdkmanDir()
+
+		expected := sdkmanDir
+
+		assert.Equal(t, expected, actual, "sdkman dir value not read from SDKMAN_DIR env var")
+	})
 }
 
-func TestSdkmanDirEnvVarSet(t *testing.T) {
-	sdkmanDir, err := ioutil.TempDir("/tmp", "sdkman-")
-	check(err)
-
-	os.Setenv(sdkmanDirEnv, sdkmanDir)
-
-	actual := SdkmanDir()
-
-	expected := sdkmanDir
-
-	assert.Equal(t, expected, actual, "sdkman dir value not read from SDKMAN_DIR env var")
+// doKeepTemp indicates tester wants to keep temporary outputs after testing.
+func doKeepTemp() bool {
+	f := os.Getenv("KEEP_TEMP")
+	if len(f) == 0 {
+		return false
+	}
+	f = strings.ToLower(f)
+	switch f {
+	case "y", "yes", "true", "on", "1":
+		return true
+	case "n", "no", "false", "off", "0":
+		return false
+	default:
+		return false
+	}
 }

--- a/env/sdkmandir_test.go
+++ b/env/sdkmandir_test.go
@@ -1,12 +1,13 @@
 package env
 
 import (
-	"github.com/mitchellh/go-homedir"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSdkmanDirNoEnvVar(t *testing.T) {

--- a/env/var_test.go
+++ b/env/var_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,17 +11,30 @@ import (
 
 func TestGetVersion(t *testing.T) {
 
-	sdkmanDir, err := ioutil.TempDir("/tmp", "sdkman-")
-	check(err)
-	defer os.RemoveAll(sdkmanDir)
+	sdkmanDir, err := ioutil.TempDir("", "sdkman-")
+	if err != nil {
+		t.Fatalf("failed to create temporal directory (%#v)", err)
+	}
+	t.Logf("sdkmanDir = %s", sdkmanDir)
+	defer (func(keep bool) {
+		if !keep {
+			_ = os.RemoveAll(sdkmanDirEnv)
+			t.Logf("delete %s", sdkmanDir)
+		}
+	})(doKeepTemp())
 
-	err = os.Mkdir(sdkmanDir+"/var", 0755)
-	check(err)
+	varPath := filepath.Join(sdkmanDir, varFile)
+	// Create a directory to store the `varFile`.
+	err = os.MkdirAll(filepath.Dir(varPath), 0755)
+	if err != nil {
+		t.Fatalf("failed to create directory \"%s\" (%#v)", filepath.Dir(varPath), err)
+	}
 
 	expected := "1.0.0"
-	err = ioutil.WriteFile(sdkmanDir+varFile, []byte(expected), os.ModePerm)
-	check(err)
-
+	err = ioutil.WriteFile(varPath, []byte(expected), os.ModePerm)
+	if err != nil {
+		t.Fatalf("failed to create %s (%#v)", varPath, err)
+	}
 	actual := GetVersion(sdkmanDir)
 	assert.Equal(t, expected, actual)
 }

--- a/env/var_test.go
+++ b/env/var_test.go
@@ -1,10 +1,11 @@
 package env
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetVersion(t *testing.T) {


### PR DESCRIPTION
Use system's default temporary directory.